### PR TITLE
fix(sqlserver): fix build of sql server 2019 docker image

### DIFF
--- a/sqlserver/2017/0_init-databases.sql
+++ b/sqlserver/2017/0_init-databases.sql
@@ -22,8 +22,8 @@ IF NOT EXISTS (SELECT name FROM master.dbo.sysdatabases WHERE name = N'bonita')
 BEGIN
     CREATE DATABASE [bonita]
     -- Enable Row Versioning-Based Isolation Levels
-    ALTER DATABASE bonita SET ALLOW_SNAPSHOT_ISOLATION OFF
-    ALTER DATABASE bonita SET READ_COMMITTED_SNAPSHOT OFF
+    ALTER DATABASE bonita SET ALLOW_SNAPSHOT_ISOLATION ON
+    ALTER DATABASE bonita SET READ_COMMITTED_SNAPSHOT ON
 END
 GO
 
@@ -32,8 +32,8 @@ IF NOT EXISTS (SELECT name FROM master.dbo.sysdatabases WHERE name = N'business_
 BEGIN
     CREATE DATABASE [business_data]
     -- Enable Row Versioning-Based Isolation Levels
-    ALTER DATABASE business_data SET ALLOW_SNAPSHOT_ISOLATION OFF
-    ALTER DATABASE business_data SET READ_COMMITTED_SNAPSHOT OFF
+    ALTER DATABASE business_data SET ALLOW_SNAPSHOT_ISOLATION ON
+    ALTER DATABASE business_data SET READ_COMMITTED_SNAPSHOT ON
 END
 GO
 

--- a/sqlserver/2017/0_init-databases.sql
+++ b/sqlserver/2017/0_init-databases.sql
@@ -22,8 +22,8 @@ IF NOT EXISTS (SELECT name FROM master.dbo.sysdatabases WHERE name = N'bonita')
 BEGIN
     CREATE DATABASE [bonita]
     -- Enable Row Versioning-Based Isolation Levels
-    ALTER DATABASE bonita SET ALLOW_SNAPSHOT_ISOLATION ON
-    ALTER DATABASE bonita SET READ_COMMITTED_SNAPSHOT ON
+    ALTER DATABASE bonita SET ALLOW_SNAPSHOT_ISOLATION OFF
+    ALTER DATABASE bonita SET READ_COMMITTED_SNAPSHOT OFF
 END
 GO
 
@@ -32,8 +32,8 @@ IF NOT EXISTS (SELECT name FROM master.dbo.sysdatabases WHERE name = N'business_
 BEGIN
     CREATE DATABASE [business_data]
     -- Enable Row Versioning-Based Isolation Levels
-    ALTER DATABASE business_data SET ALLOW_SNAPSHOT_ISOLATION ON
-    ALTER DATABASE business_data SET READ_COMMITTED_SNAPSHOT ON
+    ALTER DATABASE business_data SET ALLOW_SNAPSHOT_ISOLATION OFF
+    ALTER DATABASE business_data SET READ_COMMITTED_SNAPSHOT OFF
 END
 GO
 

--- a/sqlserver/2019/.dockerignore
+++ b/sqlserver/2019/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+README.md
+.dockerignore

--- a/sqlserver/2019/Dockerfile
+++ b/sqlserver/2019/Dockerfile
@@ -1,4 +1,6 @@
-FROM mcr.microsoft.com/mssql/server:2019-CU8-ubuntu-16.04
+FROM mcr.microsoft.com/mssql/server:2019-CU14-ubuntu-20.04
+
+USER root
 
 LABEL maintainer="Bonita R&D Runtime team: anthony.birembaut@bonitasoft.com,\
 emmanuel.duchastenier@bonitasoft.com,\

--- a/sqlserver/2019/Dockerfile
+++ b/sqlserver/2019/Dockerfile
@@ -1,7 +1,5 @@
 FROM mcr.microsoft.com/mssql/server:2019-CU14-ubuntu-20.04
 
-USER root
-
 LABEL maintainer="Bonita R&D Runtime team: anthony.birembaut@bonitasoft.com,\
 emmanuel.duchastenier@bonitasoft.com,\
 baptiste.mesta@bonitasoft.com,\
@@ -17,16 +15,25 @@ ENV MSSQL_RPC_PORT 135
 ENV MSSQL_DTC_TCP_PORT 51000
 ENV MSSQL_PID Express
 
-# Create app directory
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
+# change active user to root
+USER root
 
+# create the app directory
+RUN mkdir -p /usr/src/app
 
 # Bundle app source
 COPY . /usr/src/app
 
 # Grant permissions for the import-data script to be executable
 RUN chmod +x /usr/src/app/init-db.sh
+
+# set mssql as owner of the app directory
+RUN chown -R mssql /usr/src/app
+
+# change back to user mssql
+USER mssql
+
+WORKDIR /usr/src/app
 
 CMD /bin/bash ./entrypoint.sh
 

--- a/sqlserver/2019/README.md
+++ b/sqlserver/2019/README.md
@@ -9,6 +9,9 @@ Default value for `MSSQL_PID` environment variable is `Express`, but you can cha
 
 See more configuration on [Microsoft Official base image](https://hub.docker.com/_/microsoft-mssql-server)
 
+Check the list of available tags [on Microsoft site](https://mcr.microsoft.com/v2/mssql/server/tags/list)
+to update to the latest version.
+
 ### databases
 
 This image already contains the 2 databases:

--- a/sqlserver/2019/README.md
+++ b/sqlserver/2019/README.md
@@ -20,19 +20,19 @@ This image already contains the 2 databases:
 
 ## build it
 
-    docker build -t bonitasoft/bonita-sqlserver:2019-CU8 .
+    docker build -t bonitasoft/bonita-sqlserver:2019-CU14 .
 
 ## deploy to a registry
 
-    docker push bonitasoft/bonita-sqlserver:2019-CU8
+    docker push bonitasoft/bonita-sqlserver:2019-CU14
 
 ## run it
 
 The simple way:
 
-    docker run -d --name bonita-sqlserver-2019 -p :1433 bonitasoft/bonita-sqlserver:2019-CU8
+    docker run -d --name bonita-sqlserver-2019 -p :1433 bonitasoft/bonita-sqlserver:2019-CU14
 
 The more-complete way:
 
     docker run -d --name bonita-sqlserver-2019 -e 'MSSQL_SA_PASSWORD=S0mES3cRet!P455W0rD' -e 'MSSQL_RPC_PORT=135' -e 'MSSQL_DTC_TCP_PORT=51000' \
-        -p 51433:1433 -p 135:135 -p 51000:51000 bonitasoft/bonita-sqlserver:2019-CU8
+        -p 51433:1433 -p 135:135 -p 51000:51000 bonitasoft/bonita-sqlserver:2019-CU14


### PR DESCRIPTION
* force using of root user to fix the invalid permission on build of  2019 docker image.
* use last sqlserver tag `2019-CU14-ubuntu-20.04` as base image 