### PR TITLE
fix(sqlserver): bump to 2022-CU13

### DIFF
--- a/sqlserver/2022/Dockerfile
+++ b/sqlserver/2022/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/mssql/server:2022-CU4-ubuntu-20.04
+FROM mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-20.04
 
 # OCI annotations to image
 LABEL org.opencontainers.image.authors="Bonita R&D Engine Team <rd.engine@bonitasoft.com>" \
@@ -9,13 +9,13 @@ LABEL org.opencontainers.image.authors="Bonita R&D Engine Team <rd.engine@bonita
       org.opencontainers.image.vendor="Bonitasoft" \
       org.opencontainers.image.url="https://www.bonitasoft.com/" \
       org.opencontainers.image.licenses="GPL-2.0" \
-      org.opencontainers.image.version="2022-CU4"
+      org.opencontainers.image.version="2022-CU13"
 
-ENV ACCEPT_EULA Y
-ENV MSSQL_SA_PASSWORD DeLorean1985
-ENV MSSQL_RPC_PORT 135
-ENV MSSQL_DTC_TCP_PORT 51000
-ENV MSSQL_PID Express
+ENV ACCEPT_EULA=Y
+ENV MSSQL_SA_PASSWORD=DeLorean1985
+ENV MSSQL_RPC_PORT=135
+ENV MSSQL_DTC_TCP_PORT=51000
+ENV MSSQL_PID=Express
 
 # change active user to root
 USER root

--- a/sqlserver/2022/README.md
+++ b/sqlserver/2022/README.md
@@ -26,7 +26,7 @@ This image is configured with the two databases required by Bonita:
 The simple way:
 
 ```shell
-docker run -d --name bonita-sqlserver -p 1433:1433 bonitasoft/bonita-sqlserver:2022-CU4
+docker run -d --name bonita-sqlserver -p 1433:1433 bonitasoft/bonita-sqlserver:2022-CU13
 ```
 
 The more-complete way:
@@ -40,7 +40,7 @@ docker run -d \
       -p 1433:1433 \
       -p 135:135 \
       -p 51000:51000 \
-      bonitasoft/bonita-sqlserver:2022-CU4
+      bonitasoft/bonita-sqlserver:2022-CU13
 ```
 
 ## Container shell access


### PR DESCRIPTION
Due to an issue with latest Linux kernel, the base image version of sqlserver must be updated.

https://github.com/microsoft/mssql-docker/issues/868